### PR TITLE
Add three new pages with specific layouts

### DIFF
--- a/utility_master/lib/main.dart
+++ b/utility_master/lib/main.dart
@@ -3,13 +3,23 @@ import 'package:common_svgs/common_svgs.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:utility_master/data/crud/crud.dart';
 import 'package:utility_master/pages/app_landing.dart';
+import 'package:utility_master/pages/example_page.dart'; // Added for ExamplePage
+import 'package:utility_master/pages/fullscreen_page.dart'; // Added for FullscreenPage
+import 'package:utility_master/pages/split_horizontal_page.dart'; // Added for SplitHorizontalPage
+import 'package:utility_master/pages/split_vertical_page.dart'; // Added for SplitVerticalPage
 import 'package:utility_master/theme/bg/blurred_static_squares.dart';
 import 'package:utility_master/theme/theme_dark.dart';
 
 import 'firebase_options.dart';
 
 void main() => Arcane(
-    router: const ArcaneRouter(routes: [LandingPage()]),
+    router: const ArcaneRouter(routes: [
+      LandingPage(),
+      ExamplePage(), // Added route for ExamplePage
+      FullscreenPage(), // Added route for FullscreenPage
+      SplitHorizontalPage(), // Added route for SplitHorizontalPage
+      SplitVerticalPage(), // Added route for SplitVerticalPage
+    ]),
     firebase: DefaultFirebaseOptions.currentPlatform,
     svgLogo: svgArcaneArts,
     events: ArcaneEvents(

--- a/utility_master/lib/pages/example_page.dart
+++ b/utility_master/lib/pages/example_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'fullscreen_page.dart';
+
+class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Example Page'),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => context.go('/fullscreen'),
+          child: const Text('Go to Fullscreen Page'),
+        ),
+      ),
+    );
+  }
+}

--- a/utility_master/lib/pages/fullscreen_page.dart
+++ b/utility_master/lib/pages/fullscreen_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class FullscreenPage extends StatelessWidget {
+  const FullscreenPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Fullscreen Page'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: const Center(
+        child: Text('This is a fullscreen page.'),
+      ),
+    );
+  }
+}

--- a/utility_master/lib/pages/split_horizontal_page.dart
+++ b/utility_master/lib/pages/split_horizontal_page.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class SplitHorizontalPage extends StatelessWidget {
+  const SplitHorizontalPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Split Horizontal Page'),
+      ),
+      body: Row(
+        children: <Widget>[
+          Expanded(
+            child: Container(
+              color: Colors.red,
+              child: const Center(
+                child: Text('Left Side'),
+              ),
+            ),
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(
+            child: Container(
+              color: Colors.blue,
+              child: const Center(
+                child: Text('Right Side'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/utility_master/lib/pages/split_vertical_page.dart
+++ b/utility_master/lib/pages/split_vertical_page.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class SplitVerticalPage extends StatelessWidget {
+  const SplitVerticalPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Split Vertical Page'),
+      ),
+      body: Column(
+        children: <Widget>[
+          Expanded(
+            child: Container(
+              color: Colors.amber,
+              child: const Center(
+                child: Text('Top Side'),
+              ),
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: Container(
+              color: Colors.green,
+              child: const Center(
+                child: Text('Bottom Side'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces three new pages to the UtilityMaster app, enhancing its navigation and layout capabilities.

- **Adds ExamplePage**: Implements a new `ExamplePage` that includes a button to navigate to a fullscreen page. This page demonstrates the app's ability to transition between different views.
- **Introduces FullscreenPage**: Adds a `FullscreenPage` with a back button, allowing users to return to the previous page. This page is designed to occupy the full screen, providing a focused view for content.
- **Creates Split Screen Pages**: Two new pages are added to showcase split-screen layouts. `SplitHorizontalPage` divides the screen horizontally with a vertical divider, while `SplitVerticalPage` divides the screen vertically, each containing dummy content for demonstration purposes.
- **Updates Navigation**: Modifies `main.dart` to register the new pages in the `ArcaneRouter` routes, ensuring seamless navigation within the app.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NextdoorPsycho/UtilityMaster?shareId=8fa47d76-ee09-45ce-b645-399a424d3264).