### PR TITLE
Align license and split pages with app theme

### DIFF
--- a/utility_master/lib/pages/arcane_license.dart
+++ b/utility_master/lib/pages/arcane_license.dart
@@ -1,4 +1,5 @@
 import 'package:arcane/arcane.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 
 // This is just simulating a mapping of license names to license text data
 const Map<String, String> licenseTexts = {
@@ -21,7 +22,18 @@ class LicenseViewerScreen extends ArcaneStatelessScreen {
         appBar: AppBar(
           title: const Text("License"),
         ),
-        body: Text(licenseTexts[license] ?? "Unknown license"),
+        body: ShadCard(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(licenseTexts[license] ?? "Unknown license"),
+          ),
+          color: ShadTheme.of(context).colorScheme.card.withOpacity(0.5),
+          shadow: BoxShadow(
+            color: ShadTheme.of(context).colorScheme.shadow.withOpacity(0.5),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ),
       );
 
   // Step 1. We need to use withParams to add our params.

--- a/utility_master/lib/pages/split_horizontal_page.dart
+++ b/utility_master/lib/pages/split_horizontal_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 
 class SplitHorizontalPage extends StatelessWidget {
   const SplitHorizontalPage({Key? key}) : super(key: key);
@@ -12,19 +13,29 @@ class SplitHorizontalPage extends StatelessWidget {
       body: Row(
         children: <Widget>[
           Expanded(
-            child: Container(
-              color: Colors.red,
+            child: ShadCard(
               child: const Center(
                 child: Text('Left Side'),
+              ),
+              color: ShadTheme.of(context).colorScheme.card.withOpacity(0.5),
+              shadow: BoxShadow(
+                color: ShadTheme.of(context).colorScheme.shadow.withOpacity(0.5),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
               ),
             ),
           ),
           const VerticalDivider(width: 1),
           Expanded(
-            child: Container(
-              color: Colors.blue,
+            child: ShadCard(
               child: const Center(
                 child: Text('Right Side'),
+              ),
+              color: ShadTheme.of(context).colorScheme.card.withOpacity(0.5),
+              shadow: BoxShadow(
+                color: ShadTheme.of(context).colorScheme.shadow.withOpacity(0.5),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
               ),
             ),
           ),

--- a/utility_master/lib/pages/split_vertical_page.dart
+++ b/utility_master/lib/pages/split_vertical_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
 
 class SplitVerticalPage extends StatelessWidget {
   const SplitVerticalPage({Key? key}) : super(key: key);
@@ -12,19 +13,29 @@ class SplitVerticalPage extends StatelessWidget {
       body: Column(
         children: <Widget>[
           Expanded(
-            child: Container(
-              color: Colors.amber,
+            child: ShadCard(
               child: const Center(
                 child: Text('Top Side'),
+              ),
+              color: ShadTheme.of(context).colorScheme.card.withOpacity(0.5),
+              shadow: BoxShadow(
+                color: ShadTheme.of(context).colorScheme.shadow.withOpacity(0.5),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
               ),
             ),
           ),
           const Divider(height: 1),
           Expanded(
-            child: Container(
-              color: Colors.green,
+            child: ShadCard(
               child: const Center(
                 child: Text('Bottom Side'),
+              ),
+              color: ShadTheme.of(context).colorScheme.card.withOpacity(0.5),
+              shadow: BoxShadow(
+                color: ShadTheme.of(context).colorScheme.shadow.withOpacity(0.5),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
               ),
             ),
           ),


### PR DESCRIPTION
Updates the app's license page and example split views to align with the transparent design theme.

- **License Page**: Implements `ShadCard` widget in `arcane_license.dart` to display license content, applying the app's transparent design theme for consistency.
- **Split Views**: Replaces `Container` widgets with `ShadCard` widgets in both `split_horizontal_page.dart` and `split_vertical_page.dart`, ensuring the split views adhere to the transparent design theme. This includes setting the opacity and shadow effects to match the overall app design.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NextdoorPsycho/UtilityMaster?shareId=0b6babe0-ca55-4d06-946f-c7e875256171).