### PR TITLE
Add glassmorphic UI elements to split pages

### DIFF
--- a/utility_master/lib/pages/split_horizontal_page.dart
+++ b/utility_master/lib/pages/split_horizontal_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:utility_master/lib/theme/glass_widget_design.dart'; // Import the GlassWidgetDesign class
 
 class SplitHorizontalPage extends StatelessWidget {
   const SplitHorizontalPage({Key? key}) : super(key: key);
@@ -12,8 +13,9 @@ class SplitHorizontalPage extends StatelessWidget {
       body: Row(
         children: <Widget>[
           Expanded(
-            child: Container(
-              color: Colors.red,
+            child: GlassBox( // Use GlassBox widget from GlassWidgetDesign
+              blurX: 10.0, // Set blurX property for glassmorphic effect
+              blurY: 10.0, // Set blurY property for glassmorphic effect
               child: const Center(
                 child: Text('Left Side'),
               ),
@@ -21,8 +23,9 @@ class SplitHorizontalPage extends StatelessWidget {
           ),
           const VerticalDivider(width: 1),
           Expanded(
-            child: Container(
-              color: Colors.blue,
+            child: GlassBox( // Use GlassBox widget from GlassWidgetDesign
+              blurX: 10.0, // Set blurX property for glassmorphic effect
+              blurY: 10.0, // Set blurY property for glassmorphic effect
               child: const Center(
                 child: Text('Right Side'),
               ),

--- a/utility_master/lib/pages/split_vertical_page.dart
+++ b/utility_master/lib/pages/split_vertical_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:utility_master/lib/theme/glass_widget_design.dart'; // Import the GlassWidgetDesign class
 
 class SplitVerticalPage extends StatelessWidget {
   const SplitVerticalPage({Key? key}) : super(key: key);
@@ -12,8 +13,9 @@ class SplitVerticalPage extends StatelessWidget {
       body: Column(
         children: <Widget>[
           Expanded(
-            child: Container(
-              color: Colors.amber,
+            child: GlassBox( // Use GlassBox widget from GlassWidgetDesign
+              blurX: 10.0, // Set blurX property for glassmorphic effect
+              blurY: 10.0, // Set blurY property for glassmorphic effect
               child: const Center(
                 child: Text('Top Side'),
               ),
@@ -21,8 +23,9 @@ class SplitVerticalPage extends StatelessWidget {
           ),
           const Divider(height: 1),
           Expanded(
-            child: Container(
-              color: Colors.green,
+            child: GlassBox( // Use GlassBox widget from GlassWidgetDesign
+              blurX: 10.0, // Set blurX property for glassmorphic effect
+              blurY: 10.0, // Set blurY property for glassmorphic effect
               child: const Center(
                 child: Text('Bottom Side'),
               ),

--- a/utility_master/lib/theme/glass_widget_design.dart
+++ b/utility_master/lib/theme/glass_widget_design.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class GlassWidgetDesign {
+  static Widget GlassBox({
+    required double blurX,
+    required double blurY,
+    required Widget child,
+  }) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(10.0),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: blurX, sigmaY: blurY),
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.2),
+            borderRadius: BorderRadius.circular(10.0),
+            border: Border.all(
+              color: Colors.white.withOpacity(0.2),
+            ),
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces glassmorphic UI elements to the horizontal and vertical split pages and adds a new design class for creating glass widgets.

- **Adds `GlassWidgetDesign` class**: A new file `glass_widget_design.dart` is added under `utility_master/lib/theme/`, introducing the `GlassWidgetDesign` class with a `GlassBox` method. This method applies glassmorphic effects to widgets using `BackdropFilter` and `ClipRRect`.
- **Updates split pages**: Both `split_horizontal_page.dart` and `split_vertical_page.dart` are updated to replace `Container` widgets with `GlassBox` widgets from the newly added `GlassWidgetDesign` class. This change applies a glassmorphic effect to the UI elements on these pages, with properties set for blurring effects.
  

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NextdoorPsycho/UtilityMaster?shareId=f06f8814-e2e2-4f95-bd1f-2f8d0a2af162).